### PR TITLE
v0.5alpha

### DIFF
--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -5,7 +5,7 @@ SetTitleMatchMode, 3
 
 githubUser := "hoytdj"
 repoName := "PTCGPB"
-localVersion := "v0.4alpha"
+localVersion := "v0.5alpha"
 scriptFolder := A_ScriptDir
 zipPath := A_Temp . "\update.zip"
 extractPath := A_Temp . "\update"


### PR DESCRIPTION
Bug fixes:
- After removing a non vip friend, added a screen validation check and additional delay, in order to avoid relaunching the same friend before refresh.
- When reaching the bottom while scrolling, now checking for 3 repeat IDs (rather than 2) in order to prevent skipping the check on the last friend in certain scenarios.
- If in test mode for longer than 3 minutes, when returning to accept friends, we first decline all, in order to avoid a timeout while working through the backlog.